### PR TITLE
Expose constructor

### DIFF
--- a/Common.Logging.Fluent/FluentLoggerFactoryAdapter.cs
+++ b/Common.Logging.Fluent/FluentLoggerFactoryAdapter.cs
@@ -40,7 +40,7 @@ namespace Common.Logging.Fluent
             int timeout = properties.ParseValueOrDefault("timeout", 3000);
             bool verbose = properties.ParseValueOrDefault("verbose", false);
 
-            _sender = FluentSender.CreateSync(tag, hostname, port, bufmax, timeout, verbose).Result;
+            _sender = new FluentSender(tag, hostname, port, bufmax, timeout, verbose);
 
             _queue = new BlockingCollection<Tuple<string, object>>(new ConcurrentQueue<Tuple<string, object>>());
             _cancellation = new CancellationTokenSource();

--- a/fluent-logger-csharp/MessagePacker.cs
+++ b/fluent-logger-csharp/MessagePacker.cs
@@ -28,15 +28,20 @@ namespace Fluent
 
         public byte[] MakePacket(string label, DateTime timestamp, params object[] records)
         {
-            string tag;
-            if (!string.IsNullOrEmpty(label))
-            {
-                tag = _tag + "." + label;
-            }
-            else
-            {
-                tag = _tag;
-            }
+            string tag = "";
+
+						if (! string.IsNullOrEmpty(_tag) && ! string.IsNullOrEmpty(label))
+						{
+							tag = string.Format("{0}.{1}", _tag, label);
+						}
+						else if (! string.IsNullOrEmpty(_tag))
+						{
+							tag = _tag;
+						}
+						else if (! string.IsNullOrEmpty(label))
+						{
+							tag = label;
+						}
 
             var xs = new List<MessagePackObject>();
             xs.Add(tag);


### PR DESCRIPTION
I made a couple improvements to this project.  I found that in cases where the fluent server is unavailable, having the sender initializer block trying to connect is unsuitable, so I exposed the constructor, allowing it to initialize without blocking.

I also added a timer that is used to re-try a send operation if it fails. That way, the caller doesn't have to emit initial events to cause a retry.

I'm using it to emit log records from a web API, and it seems to be working quite well now.
